### PR TITLE
Adapt to changed coordinates for test support classes

### DIFF
--- a/kivakit-data/compression/src/main/java/com/telenav/kivakit/data/compression/DataCompressionUnitTest.java
+++ b/kivakit-data/compression/src/main/java/com/telenav/kivakit/data/compression/DataCompressionUnitTest.java
@@ -28,7 +28,6 @@ import com.telenav.kivakit.data.compression.codecs.huffman.tree.Symbols;
 import com.telenav.kivakit.primitive.collections.array.scalars.ByteArray;
 import com.telenav.kivakit.primitive.collections.list.ByteList;
 import com.telenav.kivakit.properties.PropertyMap;
-import com.telenav.kivakit.serialization.kryo.KryoUnitTest;
 import com.telenav.kivakit.serialization.kryo.types.CoreKryoTypes;
 import com.telenav.kivakit.serialization.kryo.types.KryoTypes;
 import org.jetbrains.annotations.NotNull;

--- a/kivakit-data/compression/src/main/java/com/telenav/kivakit/data/compression/KryoUnitTest.java
+++ b/kivakit-data/compression/src/main/java/com/telenav/kivakit/data/compression/KryoUnitTest.java
@@ -1,0 +1,141 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// © 2011-2021 Telenav, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.telenav.kivakit.data.compression;
+
+import com.telenav.kivakit.core.path.StringPath;
+import com.telenav.kivakit.core.value.count.Count;
+import com.telenav.kivakit.core.version.Version;
+import com.telenav.kivakit.resource.serialization.SerializableObject;
+import com.telenav.kivakit.serialization.core.SerializationSession;
+import com.telenav.kivakit.serialization.core.SerializationSessionFactory;
+import com.telenav.kivakit.serialization.kryo.types.CoreKryoTypes;
+import com.telenav.kivakit.serialization.kryo.types.KryoTypes;
+import com.telenav.kivakit.serialization.kryo.types.ResourceKryoTypes;
+import com.telenav.kivakit.test.UnitTest;
+import com.telenav.lexakai.annotations.LexakaiJavadoc;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static com.telenav.kivakit.core.version.Version.version;
+import static com.telenav.kivakit.resource.serialization.ObjectMetadata.VERSION;
+import static com.telenav.kivakit.serialization.core.SerializationSession.SessionType.RESOURCE;
+import com.telenav.kivakit.serialization.kryo.KryoObjectSerializer;
+import com.telenav.kivakit.serialization.kryo.KryoSerializationSession;
+import com.telenav.kivakit.serialization.kryo.KryoSerializationSessionFactory;
+
+/**
+ * Adds Kryo serialization testing to the {@link UnitTest} base class. Serialization of objects can be tested with:
+ *
+ * <ul>
+ *     <li>{@link #testSerialization(Object)}</li>
+ *     <li>{@link #testSerialization(Object, Version)}</li>
+ *     <li>{@link #testSessionSerialization(Object)}</li>
+ * </ul>
+ *
+ * <p>
+ * The registered types used by these methods can be specified by overriding {@link #kryoTypes()}.
+ * </p>
+ *
+ * @author jonathanl (shibo)
+ */
+@LexakaiJavadoc(complete = true)
+public class KryoUnitTest extends UnitTest
+{
+    private SerializationSessionFactory factory;
+
+    protected KryoTypes kryoTypes()
+    {
+        return new CoreKryoTypes().mergedWith(new ResourceKryoTypes());
+    }
+
+    protected SerializationSession session()
+    {
+        return sessionFactory().newSession(this);
+    }
+
+    protected final SerializationSessionFactory sessionFactory()
+    {
+        if (factory == null)
+        {
+            factory = new KryoSerializationSessionFactory(kryoTypes());
+        }
+
+        return factory;
+    }
+
+    protected <T> void testSerialization(T object, Version version)
+    {
+        var output = new ByteArrayOutputStream();
+        var serializer = new KryoObjectSerializer(kryoTypes());
+        var path = StringPath.stringPath("/a/b/c");
+
+        var write = new SerializableObject<>(object, version);
+        serializer.write(output, path, write, VERSION);
+
+        var input = new ByteArrayInputStream(output.toByteArray());
+
+        var read = serializer.read(input, path, object.getClass(), VERSION);
+        ensureEqual(write, read);
+    }
+
+    protected void testSerialization(Object object)
+    {
+        testSerialization(object, version("1.0"));
+    }
+
+    protected void testSessionSerialization(Object object)
+    {
+        testSessionSerialization(object, version("1.0"));
+    }
+
+    protected void testSessionSerialization(Object object, Version version)
+    {
+        trace("before serialization = $", object);
+
+        var output = new ByteArrayOutputStream();
+
+        var n = Count.count(3);
+
+        // Write the object n times to the session
+        {
+            var session = new KryoSerializationSession(kryoTypes());
+            session.open(output, RESOURCE, version);
+            n.loop(() -> session.write(new SerializableObject<>(object, version)));
+            session.close();
+        }
+
+        // Read the object n times from the written data
+        {
+            var session = new KryoSerializationSession(kryoTypes());
+            var input = new ByteArrayInputStream(output.toByteArray());
+            var streamVersion = session.open(input, RESOURCE);
+            ensureEqual(version, streamVersion);
+            n.loop(() ->
+            {
+                var deserialized = session.read();
+                assert deserialized != null;
+                trace("version $ after deserialization = $", deserialized.version(), deserialized.object());
+                ensureEqual(deserialized.object(), object);
+                ensureEqual(deserialized.version(), version);
+            });
+            session.close();
+        }
+    }
+}

--- a/kivakit-data/formats/csv/pom.xml
+++ b/kivakit-data/formats/csv/pom.xml
@@ -26,7 +26,11 @@
             <groupId>com.telenav.kivakit</groupId>
             <artifactId>kivakit-resource</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.telenav.kivakit</groupId>
+            <artifactId>kivakit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kivakit-hdfs-filesystem/hdfs/pom.xml
+++ b/kivakit-hdfs-filesystem/hdfs/pom.xml
@@ -30,7 +30,14 @@
             <groupId>com.telenav.kivakit</groupId>
             <artifactId>kivakit-filesystems-hdfs-proxy-spi</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>kivakit-test</artifactId>
+            
+            <!-- PENDING: Something is leaking a direct dependency on this.
+                 What?? -->
+            <!--<scope>test</scope>-->
+        </dependency>
     </dependencies>
 
     <build>
@@ -38,7 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.0.0-M6</version>
                 <configuration>
                     <excludedGroups>${exclude.test.groups}</excludedGroups>
                     <systemPropertyVariables>

--- a/kivakit-hdfs-filesystem/hdfs/src/test/java/com/telenav/kivakit/filesystems/hdfs/HdfsFileSystemTest.java
+++ b/kivakit-hdfs-filesystem/hdfs/src/test/java/com/telenav/kivakit/filesystems/hdfs/HdfsFileSystemTest.java
@@ -18,7 +18,7 @@
 
 package com.telenav.kivakit.filesystems.hdfs;
 
-import com.telenav.kivakit.core.test.SlowTest;
+import com.telenav.kivakit.core.test.support.SlowTest;
 import com.telenav.kivakit.filesystem.Folder;
 import com.telenav.kivakit.network.core.EmailAddress;
 import com.telenav.kivakit.network.core.NetworkPath;

--- a/kivakit-math/pom.xml
+++ b/kivakit-math/pom.xml
@@ -33,7 +33,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.telenav.kivakit</groupId>
+            <artifactId>kivakit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kivakit-math/src/test/java/com/telenav/kivakit/math/statistics/AverageDurationTest.java
+++ b/kivakit-math/src/test/java/com/telenav/kivakit/math/statistics/AverageDurationTest.java
@@ -18,7 +18,7 @@
 
 package com.telenav.kivakit.math.statistics;
 
-import com.telenav.kivakit.core.test.CoreUnitTest;
+import com.telenav.kivakit.core.test.support.CoreUnitTest;
 import com.telenav.kivakit.core.time.AverageDuration;
 import com.telenav.kivakit.core.time.Duration;
 import org.junit.Test;

--- a/kivakit-math/src/test/java/com/telenav/kivakit/math/statistics/AverageTest.java
+++ b/kivakit-math/src/test/java/com/telenav/kivakit/math/statistics/AverageTest.java
@@ -19,7 +19,7 @@
 package com.telenav.kivakit.math.statistics;
 
 import com.telenav.kivakit.core.math.Average;
-import com.telenav.kivakit.core.test.CoreUnitTest;
+import com.telenav.kivakit.core.test.support.CoreUnitTest;
 import org.junit.Test;
 
 public class AverageTest extends CoreUnitTest

--- a/kivakit-math/src/test/java/com/telenav/kivakit/math/statistics/StandardDeviationTest.java
+++ b/kivakit-math/src/test/java/com/telenav/kivakit/math/statistics/StandardDeviationTest.java
@@ -18,7 +18,7 @@
 
 package com.telenav.kivakit.math.statistics;
 
-import com.telenav.kivakit.core.test.CoreUnitTest;
+import com.telenav.kivakit.core.test.support.CoreUnitTest;
 import org.junit.Test;
 
 /**

--- a/kivakit-math/src/test/java/com/telenav/kivakit/math/statistics/SuccessRateTest.java
+++ b/kivakit-math/src/test/java/com/telenav/kivakit/math/statistics/SuccessRateTest.java
@@ -18,7 +18,7 @@
 
 package com.telenav.kivakit.math.statistics;
 
-import com.telenav.kivakit.core.test.CoreUnitTest;
+import com.telenav.kivakit.core.test.support.CoreUnitTest;
 import com.telenav.kivakit.core.value.level.Percent;
 import org.junit.Test;
 

--- a/kivakit-math/src/test/java/com/telenav/kivakit/math/trigonometry/TrigonometryTest.java
+++ b/kivakit-math/src/test/java/com/telenav/kivakit/math/trigonometry/TrigonometryTest.java
@@ -18,7 +18,7 @@
 
 package com.telenav.kivakit.math.trigonometry;
 
-import com.telenav.kivakit.core.test.CoreUnitTest;
+import com.telenav.kivakit.core.test.support.CoreUnitTest;
 import org.junit.Test;
 
 /**

--- a/kivakit-primitive-collections/pom.xml
+++ b/kivakit-primitive-collections/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>kivakit-conversion</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>kivakit-test</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/kivakit-primitive-collections/src/main/java/com/telenav/kivakit/primitive/collections/KryoUnitTest.java
+++ b/kivakit-primitive-collections/src/main/java/com/telenav/kivakit/primitive/collections/KryoUnitTest.java
@@ -1,0 +1,141 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// © 2011-2021 Telenav, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.telenav.kivakit.primitive.collections;
+
+import com.telenav.kivakit.core.path.StringPath;
+import com.telenav.kivakit.core.value.count.Count;
+import com.telenav.kivakit.core.version.Version;
+import com.telenav.kivakit.resource.serialization.SerializableObject;
+import com.telenav.kivakit.serialization.core.SerializationSession;
+import com.telenav.kivakit.serialization.core.SerializationSessionFactory;
+import com.telenav.kivakit.serialization.kryo.types.CoreKryoTypes;
+import com.telenav.kivakit.serialization.kryo.types.KryoTypes;
+import com.telenav.kivakit.serialization.kryo.types.ResourceKryoTypes;
+import com.telenav.kivakit.test.UnitTest;
+import com.telenav.lexakai.annotations.LexakaiJavadoc;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static com.telenav.kivakit.core.version.Version.version;
+import static com.telenav.kivakit.resource.serialization.ObjectMetadata.VERSION;
+import static com.telenav.kivakit.serialization.core.SerializationSession.SessionType.RESOURCE;
+import com.telenav.kivakit.serialization.kryo.KryoObjectSerializer;
+import com.telenav.kivakit.serialization.kryo.KryoSerializationSession;
+import com.telenav.kivakit.serialization.kryo.KryoSerializationSessionFactory;
+
+/**
+ * Adds Kryo serialization testing to the {@link UnitTest} base class. Serialization of objects can be tested with:
+ *
+ * <ul>
+ *     <li>{@link #testSerialization(Object)}</li>
+ *     <li>{@link #testSerialization(Object, Version)}</li>
+ *     <li>{@link #testSessionSerialization(Object)}</li>
+ * </ul>
+ *
+ * <p>
+ * The registered types used by these methods can be specified by overriding {@link #kryoTypes()}.
+ * </p>
+ *
+ * @author jonathanl (shibo)
+ */
+@LexakaiJavadoc(complete = true)
+public class KryoUnitTest extends UnitTest
+{
+    private SerializationSessionFactory factory;
+
+    protected KryoTypes kryoTypes()
+    {
+        return new CoreKryoTypes().mergedWith(new ResourceKryoTypes());
+    }
+
+    protected SerializationSession session()
+    {
+        return sessionFactory().newSession(this);
+    }
+
+    protected final SerializationSessionFactory sessionFactory()
+    {
+        if (factory == null)
+        {
+            factory = new KryoSerializationSessionFactory(kryoTypes());
+        }
+
+        return factory;
+    }
+
+    protected <T> void testSerialization(T object, Version version)
+    {
+        var output = new ByteArrayOutputStream();
+        var serializer = new KryoObjectSerializer(kryoTypes());
+        var path = StringPath.stringPath("/a/b/c");
+
+        var write = new SerializableObject<>(object, version);
+        serializer.write(output, path, write, VERSION);
+
+        var input = new ByteArrayInputStream(output.toByteArray());
+
+        var read = serializer.read(input, path, object.getClass(), VERSION);
+        ensureEqual(write, read);
+    }
+
+    protected void testSerialization(Object object)
+    {
+        testSerialization(object, version("1.0"));
+    }
+
+    protected void testSessionSerialization(Object object)
+    {
+        testSessionSerialization(object, version("1.0"));
+    }
+
+    protected void testSessionSerialization(Object object, Version version)
+    {
+        trace("before serialization = $", object);
+
+        var output = new ByteArrayOutputStream();
+
+        var n = Count.count(3);
+
+        // Write the object n times to the session
+        {
+            var session = new KryoSerializationSession(kryoTypes());
+            session.open(output, RESOURCE, version);
+            n.loop(() -> session.write(new SerializableObject<>(object, version)));
+            session.close();
+        }
+
+        // Read the object n times from the written data
+        {
+            var session = new KryoSerializationSession(kryoTypes());
+            var input = new ByteArrayInputStream(output.toByteArray());
+            var streamVersion = session.open(input, RESOURCE);
+            ensureEqual(version, streamVersion);
+            n.loop(() ->
+            {
+                var deserialized = session.read();
+                assert deserialized != null;
+                trace("version $ after deserialization = $", deserialized.version(), deserialized.object());
+                ensureEqual(deserialized.object(), object);
+                ensureEqual(deserialized.version(), version);
+            });
+            session.close();
+        }
+    }
+}

--- a/kivakit-primitive-collections/src/main/java/com/telenav/kivakit/primitive/collections/PrimitiveCollectionsUnitTest.java
+++ b/kivakit-primitive-collections/src/main/java/com/telenav/kivakit/primitive/collections/PrimitiveCollectionsUnitTest.java
@@ -18,7 +18,6 @@
 
 package com.telenav.kivakit.primitive.collections;
 
-import com.telenav.kivakit.serialization.kryo.KryoUnitTest;
 import com.telenav.kivakit.serialization.kryo.types.CoreKryoTypes;
 import com.telenav.kivakit.serialization.kryo.types.KryoTypes;
 

--- a/kivakit-primitive-collections/src/main/java/module-info.java
+++ b/kivakit-primitive-collections/src/main/java/module-info.java
@@ -1,9 +1,12 @@
 open module kivakit.primitive.collections
 {
     // KivaKit
+    requires transitive kivakit.serialization.core;
     requires transitive kivakit.serialization.kryo;
     requires transitive kivakit.collections;
     requires transitive kivakit.conversion;
+    requires transitive kivakit.test;
+    requires transitive kivakit.test.internal;
 
     // Module exports
     exports com.telenav.kivakit.primitive.collections;

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/ByteArrayTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/ByteArrayTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 import static com.telenav.kivakit.core.value.count.Count._20;
 
 public class ByteArrayTest extends PrimitiveCollectionsUnitTest

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/LongArrayTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/LongArrayTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 import static com.telenav.kivakit.core.value.count.Count._10;
 
 public class LongArrayTest extends PrimitiveCollectionsUnitTest

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/ShortArrayTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/ShortArrayTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 import static com.telenav.kivakit.core.value.count.Count._10;
 
 public class ShortArrayTest extends PrimitiveCollectionsUnitTest

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/SplitByteArrayTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/SplitByteArrayTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 import static com.telenav.kivakit.core.value.count.Count._10;
 
 public class SplitByteArrayTest extends PrimitiveCollectionsUnitTest

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/SplitIntArrayTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/SplitIntArrayTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 import static com.telenav.kivakit.core.value.count.Count._10;
 
 public class SplitIntArrayTest extends PrimitiveCollectionsUnitTest

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/SplitLongArrayTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/array/scalars/SplitLongArrayTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 import static com.telenav.kivakit.core.value.count.Count._10;
 
 public class SplitLongArrayTest extends PrimitiveCollectionsUnitTest

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/list/store/IntLinkedListStoreTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/list/store/IntLinkedListStoreTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
 
 public class IntLinkedListStoreTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/IntToByteMapTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/IntToByteMapTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 
 public class IntToByteMapTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/IntToIntMapTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/IntToIntMapTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 
 public class IntToIntMapTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/IntToLongMapTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/IntToLongMapTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 
 public class IntToLongMapTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/LongToByteMapTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/LongToByteMapTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 
 public class LongToByteMapTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/LongToIntMapTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/LongToIntMapTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 
 public class LongToIntMapTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/LongToLongMapTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/scalars/LongToLongMapTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 
 public class LongToLongMapTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/split/SplitLongToByteMapTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/split/SplitLongToByteMapTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 
 public class SplitLongToByteMapTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/split/SplitLongToIntMapTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/split/SplitLongToIntMapTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 
 public class SplitLongToIntMapTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/split/SplitLongToLongMapTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/map/split/SplitLongToLongMapTest.java
@@ -26,8 +26,8 @@ import org.junit.Test;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.ALLOW_REPEATS;
-import static com.telenav.kivakit.core.test.CoreUnitTest.Repeats.NO_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.ALLOW_REPEATS;
+import static com.telenav.kivakit.core.test.Repeats.NO_REPEATS;
 
 public class SplitLongToLongMapTest extends PrimitiveCollectionsUnitTest
 {

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/set/LongSetTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/set/LongSetTest.java
@@ -18,6 +18,7 @@
 
 package com.telenav.kivakit.primitive.collections.set;
 
+import com.telenav.kivakit.core.test.Repeats;
 import com.telenav.kivakit.primitive.collections.CompressibleCollection;
 import com.telenav.kivakit.primitive.collections.PrimitiveCollectionsUnitTest;
 import org.junit.Test;

--- a/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/set/SplitLongSetTest.java
+++ b/kivakit-primitive-collections/src/test/java/com/telenav/kivakit/primitive/collections/set/SplitLongSetTest.java
@@ -18,6 +18,7 @@
 
 package com.telenav.kivakit.primitive.collections.set;
 
+import com.telenav.kivakit.core.test.Repeats;
 import com.telenav.kivakit.primitive.collections.CompressibleCollection;
 import com.telenav.kivakit.primitive.collections.PrimitiveCollectionsUnitTest;
 import org.junit.Test;

--- a/kivakit-security/pom.xml
+++ b/kivakit-security/pom.xml
@@ -22,13 +22,23 @@
 
         <dependency>
             <groupId>com.telenav.kivakit</groupId>
+            <artifactId>kivakit-conversion</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.telenav.lexakai</groupId>
+            <artifactId>lexakai-annotations</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.telenav.kivakit</groupId>
             <artifactId>kivakit-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.telenav.kivakit</groupId>
-            <artifactId>kivakit-conversion</artifactId>
+            <artifactId>kivakit-test-internal</artifactId>
+            <scope>test</scope>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/kivakit-security/src/test/java/com/telenav/kivakit/security/digest/digesters/Sha1DigesterTest.java
+++ b/kivakit-security/src/test/java/com/telenav/kivakit/security/digest/digesters/Sha1DigesterTest.java
@@ -18,7 +18,7 @@
 
 package com.telenav.kivakit.security.digest.digesters;
 
-import com.telenav.kivakit.core.test.CoreUnitTest;
+import com.telenav.kivakit.core.test.support.CoreUnitTest;
 import org.junit.Test;
 
 public class Sha1DigesterTest extends CoreUnitTest

--- a/kivakit-ui/desktop/pom.xml
+++ b/kivakit-ui/desktop/pom.xml
@@ -34,6 +34,12 @@
             <artifactId>flatlaf</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>kivakit-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
Note this patch proliferates a couple of copies of KryoUnitTest, since that was simply moved into the tests sources of kyro serialization.  Those tests should get split out the same way, so subclassers can depend on the original, but best to do one thing at a time.

c.f. https://github.com/Telenav/kivakit/pull/100
