### PR TITLE
"'Topologically sort modules to potentially work around issues with broken parallel builds'"

### DIFF
--- a/kivakit-data/formats/pom.xml
+++ b/kivakit-data/formats/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-project-family</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.3</version>
         <relativePath/>
     </parent>
 

--- a/kivakit-data/pom.xml
+++ b/kivakit-data/pom.xml
@@ -28,8 +28,8 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>compression</module>
         <module>formats</module>
+        <module>compression</module>
     </modules>
 
 </project>

--- a/kivakit-hdfs-filesystem/pom.xml
+++ b/kivakit-hdfs-filesystem/pom.xml
@@ -30,9 +30,9 @@
     <modules>
     <!-- removing these from the build pending moving them to a separate repository
          for pathological things that can probably never be modularized -->
+        <module>hdfs-proxy-spi</module>
         <module>hadoop-doubly-shaded-protobuf</module>
-        <module>hdfs-proxy</module>
-	<module>hdfs-proxy-spi</module>
+	<module>hdfs-proxy</module>
 
         <module>hdfs</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,10 @@
     
     <modelVersion>4.0.0</modelVersion>
 
-<!-- test test test -->
-    
     <parent>
         <groupId>com.telenav</groupId>
         <artifactId>telenav-superpom-project-family</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.3</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,14 @@
     
     <modules>
         
-        <module>kivakit-remote-log</module>
-        <module>kivakit-hdfs-filesystem</module>
-        <module>kivakit-primitive-collections</module>
         <module>kivakit-math</module>
+        <module>kivakit-service</module>
+        <module>kivakit-hdfs-filesystem</module>
         <module>kivakit-security</module>
         <module>kivakit-ui</module>
+        <module>kivakit-primitive-collections</module>
+        <module>kivakit-remote-log</module>
         <module>kivakit-data</module>
-        <module>kivakit-service</module>
         
     </modules>
     


### PR DESCRIPTION
"'Topologically sort modules to potentially work around issues with broken parallel builds'



Related Pull Requests
---------------------

  * https://github.com/Telenav/kivakit/pull/138
  * https://github.com/Telenav/kivakit-extensions/pull/37
  * https://github.com/Telenav/kivakit-examples/pull/19


Creating Pull Requests In
-------------------------

  * kivakit topo-sort-modules -> develop
  * kivakit-examples topo-sort-modules -> develop
  * kivakit-extensions topo-sort-modules -> develop
  * kivakit-stuff topo-sort-modules -> develop
  * mesakit topo-sort-modules -> develop
  * mesakit-examples topo-sort-modules -> develop
  * mesakit-extensions topo-sort-modules -> develop
  * telenav-superpom topo-sort-modules -> develop
  * jonstuff topo-sort-modules -> develop


Metadata
--------

  * Invoked on com.telenav:telenav-build:2.0.2
  * SearchNonce: rNoMFcQ5V1-rgwrbn

##### Provenance

Generated by cactus: *cactus-maven-plugin* version _1.5.24_.

  * Mojo:		GitPullRequestMojo
  * Generation-Time:	2022-08-20T09:50:25Z
  * Plugin-Build:	tungsten bobblehead
  * Plugin-Date:	2022.08.20
  * Plugin-Commit:	2586695b880771254e2daf63f2f5f8a5cca1c96b
  * Plugin-Repo-Clean:	false
"